### PR TITLE
Add ImageOptionsFromBytes Method for Embedding Images from Binary Data

### DIFF
--- a/fpdf_example_test.go
+++ b/fpdf_example_test.go
@@ -23,6 +23,7 @@ package fpdf_test
 import (
 	"bufio"
 	"bytes"
+	"embed"
 	"fmt"
 	"io"
 	"math"
@@ -657,6 +658,39 @@ func ExampleFpdf_ImageOptions() {
 	example.SummaryCompare(err, fileStr)
 	// Output:
 	// Successfully generated pdf/Fpdf_ImageOptions.pdf
+}
+
+//go:embed image/*
+var imageStaticFiles embed.FS
+
+func getImageData(fileName string) ([]byte, error) {
+	data, err := imageStaticFiles.ReadFile("image/" + fileName)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func ExampleFpdf_ImageOptionsFromBytes() {
+	var opt fpdf.ImageOptions
+
+	pdf := fpdf.New("P", "mm", "A4", "")
+	pdf.AddPage()
+	pdf.SetFont("Arial", "", 11)
+	pdf.SetX(60)
+	opt.ImageType = "png"
+	imageData, err := getImageData("gofpdf.png")
+	if err != nil {
+		pdf.SetError(err)
+	}
+	pdf.ImageOptionsFromBytes("gofpdf.png", -10, 10, 30, 0, false, opt, 0, "", imageData)
+	opt.AllowNegativePosition = true
+	pdf.ImageOptionsFromBytes("gofpdf.png", -10, 50, 30, 0, false, opt, 0, "", imageData)
+	fileStr := example.Filename("Fpdf_ImageOptionsFromBytes")
+	err = pdf.OutputFileAndClose(fileStr)
+	example.SummaryCompare(err, fileStr)
+	// Output:
+	// Successfully generated pdf/Fpdf_ImageOptionsFromBytes.pdf
 }
 
 // ExampleFpdf_RegisterImageOptionsReader demonstrates how to load an image


### PR DESCRIPTION
Parameters:
imageNameStr: The name of the image.
x, y: Coordinates for placing the image.
w, h: Dimensions of the image. If one is set to 0, the aspect ratio is maintained.
flow: Boolean to determine if the image should flow to the next line.
options: An ImageOptions struct for additional configurations such as image type and DPI.
link: Integer for associating a link with the image.
linkStr: URL string for associating a hyperlink with the image.
imageData: Byte slice containing the binary image data.
The method internally calls RegisterImageOptionsFromBytes to register the image and uses imageOut to render it on the page.
Added detailed documentation for the method, including parameter descriptions and an example usage.

This enhancement enables embedding images from in-memory binary data, which is useful for dynamic image generation or working with images from external sources such as HTTP responses. It maintains consistency with the existing ImageOptions API.